### PR TITLE
Update DungeonJournal runtime to 46

### DIFF
--- a/io.github.trytonvanmeer.DungeonJournal.json
+++ b/io.github.trytonvanmeer.DungeonJournal.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.trytonvanmeer.DungeonJournal",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "dungeonjournal",
     "finish-args": [


### PR DESCRIPTION
- Update DungeonJournal runtime to 46 since runtime version 44 has reached end-of-life.