### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/io.github.trytonvanmeer.DungeonJournal.json
+++ b/io.github.trytonvanmeer.DungeonJournal.json
@@ -12,18 +12,6 @@
         "--socket=wayland",
         "--metadata=X-DConf=migrate-path=/io/github/trytonvanmeer/DungeonJournal/"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "/share/vala",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
         {
             "name": "dungeonjournal",


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.